### PR TITLE
chore: align Node engine with jscpd

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -33,7 +33,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
-## @modelcontextprotocol/sdk (1.28.0)
+## @modelcontextprotocol/sdk (1.29.0)
 
 - License: MIT
 - Repository: https://github.com/modelcontextprotocol/typescript-sdk
@@ -122,7 +122,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
-## ajv (8.18.0)
+## ajv (8.20.0)
 
 - License: MIT
 - Repository: https://github.com/ajv-validator/ajv
@@ -180,7 +180,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ```
 
-## better-sqlite3 (12.8.0)
+## better-sqlite3 (12.11.1)
 
 - License: MIT
 - Repository: https://github.com/WiseLibs/better-sqlite3

--- a/docs/dev-reference.md
+++ b/docs/dev-reference.md
@@ -5,7 +5,7 @@
 
 - **Package**: `deft-mcp` v1.0.0-beta.5
 - **License**: GPL-3.0-only
-- **Node**: `>=22.0.0`
+- **Node**: `>=22.12.0`
 - **Module System**: `module`
 
 ## Runtime Toolchain (mise)

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "vitest": "^4.1.0"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "typecheck": "tsc --noEmit"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.12.0"
   },
   "license": "GPL-3.0-only",
   "keywords": [


### PR DESCRIPTION
Align the declared minimum Node.js version with commander@15, introduced by Renovate PR #25. Includes regenerated third-party notices reflecting dependency versions already present on main.